### PR TITLE
Sendinblue is now Brevo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ https://docs.github20k.com
  ### [Newsletter](https://github.com/github-20k/course/tree/main/src/services/newsletter/providers)
  - [x] [MailChimp](https://mailchimp.com)
  - [x] [Beehiiv](https://beehiiv.com)
- - [ ] [Sendinblue](https://sendinblue.com)
+ - [ ] [Brevo (formerly Sendinblue)](https://brevo.com)
  - [ ] [MailerLite](https://www.mailerlite.com)
  - [ ] [Drip](https://www.drip.com)
  - [ ] [Moosend](https://moosend.com)


### PR DESCRIPTION
Sendinblue is now **Brevo**


## Description
Updated README.md to show `Brevo`

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix
- [ ] New Provider
- [ ] Styling
- [ ] New Feature
- [x] Doc/Readme update